### PR TITLE
Use Fibers to handle IO concurrently

### DIFF
--- a/src/rosegold/packets/clientbound/encryption_request.cr
+++ b/src/rosegold/packets/clientbound/encryption_request.cr
@@ -18,7 +18,7 @@ class Rosegold::Clientbound::EncryptionRequest < Rosegold::Clientbound::Packet
   def callback(client)
     encryption_response = Serverbound::EncryptionResponse.new self
 
-    client.send_packet encryption_response
+    client.send_packet! encryption_response
 
     client.io = Minecraft::EncryptedTCPSocket.new \
       client.io,

--- a/src/rosegold/packets/clientbound/keep_alive.cr
+++ b/src/rosegold/packets/clientbound/keep_alive.cr
@@ -12,6 +12,6 @@ class Rosegold::Clientbound::KeepAlive < Rosegold::Clientbound::Packet
   end
 
   def callback(client)
-    client.send_packet Serverbound::KeepAlive.new keep_alive_id
+    client.queue_packet Serverbound::KeepAlive.new keep_alive_id
   end
 end

--- a/src/rosegold/packets/clientbound/login_plugin_request.cr
+++ b/src/rosegold/packets/clientbound/login_plugin_request.cr
@@ -16,7 +16,7 @@ class Rosegold::Clientbound::LoginPluginRequest < Rosegold::Clientbound::Packet
   end
 
   def callback(client)
-    client.send_packet Serverbound::LoginPluginResponse.new(
+    client.queue_packet Serverbound::LoginPluginResponse.new(
       self.message_id
     )
   end

--- a/src/rosegold/packets/clientbound/ping.cr
+++ b/src/rosegold/packets/clientbound/ping.cr
@@ -12,6 +12,6 @@ class Rosegold::Clientbound::Ping < Rosegold::Clientbound::Packet
   end
 
   def callback(client)
-    client.send_packet Serverbound::Pong.new ping_id
+    client.queue_packet Serverbound::Pong.new ping_id
   end
 end

--- a/src/rosegold/packets/clientbound/player_position_and_look.cr
+++ b/src/rosegold/packets/clientbound/player_position_and_look.cr
@@ -56,7 +56,7 @@ class Rosegold::Clientbound::PlayerPositionAndLook < Rosegold::Clientbound::Pack
   end
 
   def callback(client)
-    client.send_packet Serverbound::TeleportConfirm.new teleport_id
+    client.queue_packet Serverbound::TeleportConfirm.new teleport_id
 
     # TODO: set client feet/look
     # TODO: close the “Downloading Terrain” screen when joining/respawning

--- a/src/rosegold/packets/serverbound/player_look.cr
+++ b/src/rosegold/packets/serverbound/player_look.cr
@@ -16,7 +16,7 @@ class Rosegold::Serverbound::PlayerLook < Rosegold::Serverbound::Packet
 
   def to_packet : Minecraft::IO
     Minecraft::IO::Memory.new.tap do |buffer|
-      buffer.write_var_int PACKET_ID
+      buffer.write PACKET_ID
       buffer.write yaw_deg
       buffer.write pitch_deg
       buffer.write on_ground


### PR DESCRIPTION
This prepares us to use fibers to handle a physics clock

Use queue_packet to queue a packet via a fiber
Use send_packet! if you must override this behavior
