### PR TITLE
Fix KeepAlives

### DIFF
--- a/src/minecraft/io.cr
+++ b/src/minecraft/io.cr
@@ -59,6 +59,10 @@ module Minecraft::IO
     read_bytes Int32, ::IO::ByteFormat::BigEndian
   end
 
+  def read_long : Int64
+    read_bytes Int64, ::IO::ByteFormat::BigEndian
+  end
+
   def read_float : Float32
     read_bytes Float32, ::IO::ByteFormat::BigEndian
   end

--- a/src/rosegold/packets/clientbound/keep_alive.cr
+++ b/src/rosegold/packets/clientbound/keep_alive.cr
@@ -1,17 +1,18 @@
 class Rosegold::Clientbound::KeepAlive < Rosegold::Clientbound::Packet
   property \
-    keep_alive_id : UInt64
+    keep_alive_id : Int64
 
-  def initialize(@keep_alive_id : UInt64)
+  def initialize(@keep_alive_id : Int64)
   end
 
   def self.read(packet)
     self.new(
-      packet.read_var_int
+      packet.read_long
     )
   end
 
   def callback(client)
+    Log.debug { "rx <- KeepAlive: #{@keep_alive_id}" }
     client.queue_packet Serverbound::KeepAlive.new keep_alive_id
   end
 end

--- a/src/rosegold/packets/serverbound/keep_alive.cr
+++ b/src/rosegold/packets/serverbound/keep_alive.cr
@@ -4,13 +4,14 @@ class Rosegold::Serverbound::KeepAlive < Rosegold::Serverbound::Packet
   PACKET_ID = 0x0f_u8
 
   property \
-    keep_alive_id : UInt64
+    keep_alive_id : Int64
 
   def initialize(
-    @keep_alive_id : UInt64
+    @keep_alive_id : Int64
   ); end
 
   def to_packet : Minecraft::IO
+    Log.debug { "tx -> KeepAlive: #{keep_alive_id}" }
     Minecraft::IO::Memory.new.tap do |buffer|
       buffer.write PACKET_ID
       buffer.write_full keep_alive_id


### PR DESCRIPTION
Before, we were reading a var_int, which was resulting in 0
Now we're reading it as a BigEndian long, which is proper
and we can return the ID the server expects